### PR TITLE
Revert to Default Decorations

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,8 +2,6 @@ use std::fs::{ self, File };
 use std::io::Write;
 use std::path::Path;
 
-use tauri::{ WebviewUrl, WebviewWindowBuilder };
-
 /// Saves a file to the system with 'content' at location 'path'.
 /// A result type will be returned depending on whether the operation succeded or failed, and why.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,28 +54,8 @@ pub fn run() {
     tauri::Builder
         ::default()
         .plugin(tauri_plugin_fs::init())
-        .setup(|app| {
-            // Set application window defaults
-            let win_builder = WebviewWindowBuilder::new(app, "notepad", WebviewUrl::default())
-                .title("Notepad.me")
-                .inner_size(800.0, 600.0);
-
-            // Set blank title for macos
-            #[cfg(target_os = "macos")]
-            let win_builder = win_builder.title("");
-
-            // Since linux distros tend to handle decorations, we can disable them for linux.
-            #[cfg(target_os = "linux")]
-            let win_builder = win_builder.decorations(false);
-
-            // TODO: set color of window bar on macos based on application color scheme
-
-            let _window = win_builder.build().unwrap();
-
-            Ok(())
-        })
-        .invoke_handler(tauri::generate_handler![save_file, create_file, create_directory])
         .plugin(tauri_plugin_opener::init())
+        .invoke_handler(tauri::generate_handler![save_file, create_file, create_directory])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,7 +12,14 @@
   "app": {
     "security": {
       "csp": null
-    }
+    },
+    "windows": [
+      {
+        "width": 800,
+        "height": 600,
+        "title": "Notepad.me"
+      }
+    ]
   },
   "bundle": {
     "active": true,


### PR DESCRIPTION
# What Changed
logic for choosing whether or not decorations are used on different operating systems was removed. The assumption these would be handled was incorrect and will either need to be handled explicitly in the future, or implicitly for now #43.

