### PR TITLE
Update Notepad.me to Notespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Notepad.me
-Notepad.me follows the philosophy of only doing as much as it needs to. If a feature is not necessary for the bare functionality of 'notetaking', it is not added.
+# Notespace
+Notespace follows the philosophy of only doing as much as it needs to. If a feature is not necessary for the bare functionality of 'notetaking', it is not added.
 
 ## What is a notetaking application?
 A Notetaking application is more focused than a text editor. Instead of the broad goal of making editing any plain text document a pleasant experience, a notetaking application wants to be exceptionally good at editing *note* documents.
@@ -7,4 +7,4 @@ A Notetaking application is more focused than a text editor. Instead of the broa
 These documents are markdown documents automatically rendered when viewed, and stored for the user as plaintext markdown on disk. 
 
 ## What does this mean for me?
-Notepad.me is an exceptional tool for those who need to write things down in a clean and user friendly way.
+Notespace is an exceptional tool for those who need to write things down in a clean and user friendly way.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2136,7 +2136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
-name = "notepadme"
+name = "notespace"
 version = "0.1.0"
 dependencies = [
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 # The `_lib` suffix may seem redundant but it is necessary
 # to make the lib name unique and wouldn't conflict with the bin name.
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
-name = "notepadme_lib"
+name = "notespace_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "notepadme"
+name = "notespace"
 version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,7 +3,7 @@
   "identifier": "default",
   "description": "Capability for the main window",
   "windows": [
-    "notepad"
+    "notespace"
   ],
   "permissions": [
     "core:default",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    notepadme_lib::run()
+    notespace_lib::run()
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "notepad.me",
+  "productName": "notespace",
   "version": "0.1.0",
-  "identifier": "com.notepadme.app",
+  "identifier": "com.notespace.app",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
@@ -17,7 +17,7 @@
       {
         "width": 800,
         "height": 600,
-        "title": "Notepad.me"
+        "title": "Notespace"
       }
     ]
   },

--- a/src/Components/Utils/FileManagement.tsx
+++ b/src/Components/Utils/FileManagement.tsx
@@ -16,7 +16,7 @@ export const CreateFile = ({ path }: { path: string }) =>
 export const CreateDirectory = async ({ path }: { path: string }) => {
   // Grab the user's base directory; this will need to change at some point.
   const baseDir = await homeDir();
-  const hiddenBase = await join(baseDir, ".notepad");
+  const hiddenBase = await join(baseDir, ".notespace");
   const fullPath = await join(hiddenBase, path);
 
   return invoke("create_directory", { path: fullPath }); // Ensure `name` matches the expected parameter type


### PR DESCRIPTION
# What Changed
All references to Notepad.me were changed to Notespace. Additionally, the hidden folder `.notepad` was updated to `.notespace`.